### PR TITLE
Change installation instruction to `add`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Built as an ergonomic wrapper around the `libsbml` C++ library with type-safe Ru
 Currently available through Git:
 
 ```bash
-cargo install libsbml
+cargo add libsbml
 ```
 
 Please note, the C++ dependency `libsbml` is automatically installed using `cargo-vcpkg`. You dont need to link the library manually, but note that the `build.rs` script will install `cargo-vcpkg` if it is not found in your environment.


### PR DESCRIPTION
As highlighted in #13 there is an error in the Readme, which says `cargo install libsbml` instead of `cargo add libsbml`. Since this is not a binary but an `rlib` it should be `add` instead. Thanks @unaimed for spotting this!

* Closes #13 